### PR TITLE
FAI-5988 Update deps and add constraints to fix airbyte server vulns

### DIFF
--- a/airbyte-container-orchestrator/build.gradle
+++ b/airbyte-container-orchestrator/build.gradle
@@ -5,7 +5,7 @@ plugins {
 dependencies {
     implementation 'io.fabric8:kubernetes-client:5.12.2'
     implementation 'org.apache.commons:commons-lang3:3.11'
-    implementation 'org.apache.commons:commons-text:1.9'
+    implementation 'org.apache.commons:commons-text:1.10.0'
     implementation 'org.eclipse.jetty:jetty-server:9.4.31.v20200723'
     implementation 'org.eclipse.jetty:jetty-servlet:9.4.31.v20200723'
 

--- a/airbyte-server/build.gradle
+++ b/airbyte-server/build.gradle
@@ -3,6 +3,14 @@ plugins {
 }
 
 dependencies {
+    constraints {
+        implementation 'com.github.jnr:jnr-posix:3.1.8'
+        implementation 'org.eclipse.jetty:jetty-io:11.0.10'
+        implementation 'com.google.protobuf:protobuf-java:3.21.7'
+        implementation 'io.netty:netty-codec:4.1.68.Final'
+        implementation 'com.google.oauth-client:google-oauth-client:1.33.3'
+    }
+
     implementation project(':airbyte-analytics')
     implementation project(':airbyte-api')
     implementation project(':airbyte-commons-docker')
@@ -29,7 +37,7 @@ dependencies {
     implementation 'com.github.slugify:slugify:2.4'
     implementation 'commons-cli:commons-cli:1.4'
     implementation 'io.temporal:temporal-sdk:1.8.1'
-    implementation 'org.apache.cxf:cxf-core:3.4.2'
+    implementation 'org.apache.cxf:cxf-core:3.5.5'
     implementation 'org.eclipse.jetty:jetty-server:9.4.31.v20200723'
     implementation 'org.eclipse.jetty:jetty-servlet:9.4.31.v20200723'
     implementation 'org.glassfish.jaxb:jaxb-runtime:3.0.2'

--- a/airbyte-workers/build.gradle
+++ b/airbyte-workers/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation 'io.temporal:temporal-sdk:1.8.1'
     implementation 'org.apache.ant:ant:1.10.10'
     implementation 'org.apache.commons:commons-lang3:3.11'
-    implementation 'org.apache.commons:commons-text:1.9'
+    implementation 'org.apache.commons:commons-text:1.10.0'
     implementation 'org.quartz-scheduler:quartz:2.3.2'
     implementation libs.micrometer.statsd
     implementation 'io.sentry:sentry:6.3.1'


### PR DESCRIPTION
Update deps and add constraints to fix airbyte server vulns
![Screenshot 2023-05-02 at 1 53 11 PM](https://user-images.githubusercontent.com/99700024/235745688-685cecc8-b0e8-4ef1-a303-325a37e95338.png)
![Screenshot 2023-05-02 at 1 52 57 PM](https://user-images.githubusercontent.com/99700024/235745718-7693ec80-8e4c-4f05-a8c5-3f6ae721a393.png)
