### PR TITLE
FAI-5988 Upgrade org.eclipse.jetty:jetty-io

### DIFF
--- a/airbyte-server/build.gradle
+++ b/airbyte-server/build.gradle
@@ -8,6 +8,7 @@ dependencies {
         implementation 'com.google.protobuf:protobuf-java:3.21.7'
         implementation 'io.netty:netty-codec:4.1.68.Final'
         implementation 'com.google.oauth-client:google-oauth-client:1.33.3'
+        implementation 'org.eclipse.jetty:jetty-io:9.4.40.v20210413'
     }
 
     implementation project(':airbyte-analytics')


### PR DESCRIPTION
https://us-east-1.console.aws.amazon.com/ecr/repositories/private/385658942031/airbyte/_/image/sha256:2a6ee9f51dbed2d3a50f9fd880450d345c3b22779f36508e34f2f472a06d64ae/scan-results?region=us-east-1

I'm hoping the `openldap` one will go away when we change the base image