### PR TITLE
Delete removed link from checks

### DIFF
--- a/airbyte-webapp/src/config/links.ts
+++ b/airbyte-webapp/src/config/links.ts
@@ -6,7 +6,6 @@ const BASE_DOCS_LINK = "https://docs.airbyte.com";
 
 export const links = {
   dbtCommandsReference: "https://docs.getdbt.com/reference/dbt-commands",
-  technicalSupport: `${BASE_DOCS_LINK}/troubleshooting/on-deploying`,
   termsLink: "https://airbyte.com/terms",
   privacyLink: "https://airbyte.com/privacy-policy",
   helpLink: "https://airbyte.com/community",

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/ShowLoadingMessage.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/ShowLoadingMessage.tsx
@@ -26,7 +26,7 @@ const ShowLoadingMessage: React.FC<ShowLoadingMessageProps> = ({ connector }) =>
       id="form.tooLong"
       values={{
         lnk: (...lnk: React.ReactNode[]) => (
-          <Link target="_blank" href={config.links.technicalSupport} as="a">
+          <Link target="_blank" href={config.links.docsLink} as="a">
             {lnk}
           </Link>
         ),


### PR DESCRIPTION
Fixes failing task `./gradlew :airbyte-webapp:validateLinks`

There's a test that checks [live links](https://github.com/faros-ai/airbyte/blob/3c1ed696d01cf51f9ae98b87820400ee43dce45a/airbyte-webapp/src/config/links.ts#L9) and they seem to have removed https://docs.airbyte.com/troubleshooting/on-deploying from their live docs:
<img width="1201" alt="Screenshot 2023-05-17 at 10 46 10 AM" src="https://github.com/faros-ai/airbyte/assets/99700024/a9975d86-a40f-4db3-b703-945a03b4097d">
